### PR TITLE
💅 atproto and bluesky terms (minor)

### DIFF
--- a/draft-caballero-cbor-cborc42.md
+++ b/draft-caballero-cbor-cborc42.md
@@ -412,7 +412,7 @@ This creates three major issues for CBOR parsers that are not highly configurabl
 
 1. The drastically reduced set of types and tags, as well as the requirement that map keys be typed as strings, usually require enformcement at the application layer, i.e. as "ALDR"s.
 2. Configuring a generic library to _encode_ CBOR according to this profile's map-sorting requirement, when that library does not support [RFC7049] Canonical-CBOR sort mode (sometimes called "legacy" or "lengthfirst"), can be a substantial burden, and may require implementing that sorting algorithm at the application layer if the parser allows preserving map order in input.
-3. Issues around `float` reduction are harder to triage at the application layer, although many ALDRs and applications that use this encoding (such as that of the BlueSky social network and the data model of its underlying "Authenticated Data Protocol") completely sidestep the issue by simply disallowing floats at the CBOR level, or transcoding floats to a "virtual type" at the application layer, e.g. by retyping floats as strings.
+3. Issues around `float` reduction are harder to triage at the application layer, although many ALDRs and applications that use this encoding (such as that of the Bluesky social network and the data model of its underlying "Authenticated Transfer Protocol") completely sidestep the issue by simply disallowing floats at the CBOR level, or transcoding floats to a "virtual type" at the application layer, e.g. by retyping floats as strings.
 
 # Decoding Strictness
 


### PR DESCRIPTION
"Bluesky" (the company and the app) consistently does not use any special capitalization (eg, does not use "BlueSky").

The name of the protocol is "Authenticated Transfer Protocol", or "AT Protocol", or "atproto".